### PR TITLE
Add dockerhub link for acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository contains images for [cg-deck](https://github.com/18F/cg-deck)
 
 This repository contains:
 
-- `cg-deck-acceptance-test-onbuild`: A standard image to run the acceptance tests for cg-deck.
+- [`cg-deck-acceptance-test-onbuild`](https://hub.docker.com/r/18fgsa/cg-deck-acceptance-test-onbuild/): A standard image to run the acceptance tests for cg-deck.


### PR DESCRIPTION
Including the link to the docker hub page for the acceptance image
